### PR TITLE
Add calculation history panel below calculator

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Display from "./Display";
 import ButtonPanel from "./ButtonPanel";
+import HistoryPanel from "./HistoryPanel";
 import calculate from "../logic/calculate";
 import "./App.css";
 
@@ -9,10 +10,39 @@ export default class App extends React.Component {
     total: null,
     next: null,
     operation: null,
+    history: [], // Array of {expression, result}
+    previousState: null, // To help with tracking completed calculations
   };
 
   handleClick = buttonName => {
-    this.setState(calculate(this.state, buttonName));
+    this.setState(prevState => {
+      const newState = calculate(prevState, buttonName);
+      // Check if calculation is finished (i.e. '=' pressed and total updated)
+      if (
+        buttonName === '=' &&
+        prevState.next !== null &&
+        (newState.total !== null || newState.next !== null)
+      ) {
+        // Try to reconstruct the expression
+        let expression = `${prevState.total || ''}${prevState.operation || ''}${prevState.next || ''}`;
+        // Fallback if no operation (just number)
+        if (!prevState.operation) {
+          expression = prevState.next || prevState.total || '';
+        }
+        const result = newState.total || newState.next || '';
+        // Add to history, limit to last 10
+        const newHistory = [
+          { expression, result },
+          ...prevState.history,
+        ].slice(0, 10);
+        return { ...newState, history: newHistory, previousState: { ...prevState } };
+      }
+      // Reset on 'AC' (All Clear)
+      if (buttonName === 'AC') {
+        return { ...newState, history: [], previousState: { ...prevState } };
+      }
+      return { ...newState, previousState: { ...prevState } };
+    });
   };
 
   render() {
@@ -20,6 +50,7 @@ export default class App extends React.Component {
       <div className="component-app">
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
+        <HistoryPanel history={this.state.history} />
       </div>
     );
   }

--- a/src/component/HistoryPanel.css
+++ b/src/component/HistoryPanel.css
@@ -1,0 +1,43 @@
+.history-panel {
+  margin-top: 2rem;
+  background: #f8f8f8;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+}
+.history-panel h3 {
+  margin-top: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.history-item {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 0.25rem;
+  font-family: monospace;
+  color: #222;
+}
+.expression {
+  margin-right: 0.35em;
+  color: #444;
+}
+.equals {
+  color: #999;
+  margin: 0 0.25em;
+}
+.result {
+  color: #5b10a9;
+  font-weight: 700;
+}
+.history-empty {
+  color: #aaa;
+  font-style: italic;
+  padding-top: 0.2rem;
+}

--- a/src/component/HistoryPanel.js
+++ b/src/component/HistoryPanel.js
@@ -1,0 +1,23 @@
+import React from "react";
+import "./HistoryPanel.css";
+
+export default function HistoryPanel({ history }) {
+  return (
+    <div className="history-panel">
+      <h3>History</h3>
+      {history.length === 0 ? (
+        <div className="history-empty">No calculations yet.</div>
+      ) : (
+        <ul className="history-list">
+          {history.map((item, idx) => (
+            <li key={idx} className="history-item">
+              <span className="expression">{item.expression}</span>
+              <span className="equals"> = </span>
+              <span className="result">{item.result}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Introduces a HistoryPanel React component to display the last 10 calculations.
- Updates App state and calculation logic to record completed operations in a history array.
- Renders the history panel below the main calculator display for usability
- Adds clear styling to the new panel for separation from the calculator UI

History is cleared with the 'AC' button. This implementation is display-only and does not yet support click-to-reuse or exporting history.