### PR TITLE
Add square root (√) button with immediate calculation and error on negative input

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -20,6 +20,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="AC" clickHandler={this.handleClick} />
           <Button name="+/-" clickHandler={this.handleClick} />
           <Button name="%" clickHandler={this.handleClick} />
+          <Button name="√" clickHandler={this.handleClick} />
           <Button name="÷" clickHandler={this.handleClick} orange />
         </div>
         <div>

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,6 +13,25 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (buttonName === "√") {
+    // Apply sqrt to next if present, else to total. Error if negative or NaN.
+    const val = obj.next != null ? obj.next : obj.total;
+    if (val == null) return {};
+    const num = parseFloat(val);
+    if (num < 0) {
+      return {
+        total: null,
+        next: 'Error',
+        operation: null,
+      };
+    }
+    return {
+      total: null,
+      next: Math.sqrt(num).toString(),
+      operation: null,
+    };
+  }
+
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
### Features:
- Calculator UI now includes a √ button.
- Pressing √ applies square root to the current value (next/total) if non-negative.
- If the value is negative, displays "Error".
- Behavior is immediate, like AC or +/-.

#### Modified Files:
- ButtonPanel.js (UI: new button)
- calculate.js (logic: handle button, error for negative)

Tested for correct application and error display.
