### PR TITLE
Add sine, cosine, and tangent buttons to calculator

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -17,6 +17,11 @@ export default class ButtonPanel extends React.Component {
     return (
       <div className="component-button-panel">
         <div>
+          <Button name="sin" clickHandler={this.handleClick} />
+          <Button name="cos" clickHandler={this.handleClick} />
+          <Button name="tan" clickHandler={this.handleClick} />
+        </div>
+        <div>
           <Button name="AC" clickHandler={this.handleClick} />
           <Button name="+/-" clickHandler={this.handleClick} />
           <Button name="%" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,6 +13,34 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (["sin", "cos", "tan"].includes(buttonName)) {
+    // Trigonometric functions use radians; input assumed to be degrees, so convert to radians:
+    let value = null;
+    if (obj.next !== null && obj.next !== undefined) {
+      value = parseFloat(obj.next);
+    } else if (obj.total !== null && obj.total !== undefined) {
+      value = parseFloat(obj.total);
+    }
+    if (value === null || isNaN(value)) {
+      return {};
+    }
+    const radians = value * (Math.PI / 180);
+    let result = "";
+    if (buttonName === "sin") {
+      result = Math.sin(radians);
+    } else if (buttonName === "cos") {
+      result = Math.cos(radians);
+    } else if (buttonName === "tan") {
+      result = Math.tan(radians);
+    }
+    // Round to avoid long decimals
+    result = Math.round((result + Number.EPSILON) * 1000000000) / 1000000000;
+    return {
+      total: result.toString(),
+      next: null,
+      operation: null,
+    };
+  }
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
This PR adds three new buttons (sin, cos, tan) for trigonometric calculations to the top row of the calculator.

- UI: Inserts a row for the trig function buttons above the existing buttons in ButtonPanel.
- Logic: Implements calculation logic in calculate.js, handling 'sin', 'cos', and 'tan' with input interpreted as degrees (converted to radians) and outputs rounded.
- Trig operations work on current 'next' value if present, otherwise the 'total'. If neither, the buttons have no effect.

Visual, manual, and code logic review included. No regressions detected in other functionality.