### PR TITLE
Add square (x²) and square root (√) functionality to calculator

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -17,6 +17,8 @@ export default class ButtonPanel extends React.Component {
     return (
       <div className="component-button-panel">
         <div>
+          <Button name="x²" clickHandler={this.handleClick} />
+          <Button name="√" clickHandler={this.handleClick} />
           <Button name="sin" clickHandler={this.handleClick} />
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,6 +13,40 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (["x²", "√"].includes(buttonName)) {
+    let value = null;
+    if (obj.next !== null && obj.next !== undefined) {
+      value = parseFloat(obj.next);
+    } else if (obj.total !== null && obj.total !== undefined) {
+      value = parseFloat(obj.total);
+    }
+    if (value === null || isNaN(value)) {
+      return {};
+    }
+    let result = null;
+    if (buttonName === "x²") {
+      result = value * value;
+    } else if (buttonName === "√") {
+      if (value < 0) {
+        result = 'Invalid';
+        return {
+          total: result,
+          next: null,
+          operation: null,
+        };
+      }
+      result = Math.sqrt(value);
+    }
+    // Round to avoid long decimals
+    if (typeof result === 'number') {
+      result = Math.round((result + Number.EPSILON) * 1000000000) / 1000000000;
+    }
+    return {
+      total: result.toString(),
+      next: null,
+      operation: null,
+    };
+  }
   if (["sin", "cos", "tan"].includes(buttonName)) {
     // Trigonometric functions use radians; input assumed to be degrees, so convert to radians:
     let value = null;


### PR DESCRIPTION
This pull request adds support for square (x²) and square root (√) calculations in the calculator.

- Two new buttons (x² and √) have been placed at the top of the ButtonPanel.
- Calculation logic has been added to handle squaring and square root operations.
- Displays 'Invalid' for sqrt of negative numbers.

Tested by squaring, sqrt, and using them in combination with other functions. Existing behavior is unchanged.

Files modified:
- src/component/ButtonPanel.js
- src/logic/calculate.js