### PR TITLE
Add log (base 10) and ln (natural log) buttons and calculation logic

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -17,6 +17,8 @@ export default class ButtonPanel extends React.Component {
     return (
       <div className="component-button-panel">
         <div>
+          <Button name="log" clickHandler={this.handleClick} />
+          <Button name="ln" clickHandler={this.handleClick} />
           <Button name="sin" clickHandler={this.handleClick} />
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,8 +13,8 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
-  if (["sin", "cos", "tan"].includes(buttonName)) {
-    // Trigonometric functions use radians; input assumed to be degrees, so convert to radians:
+  if (["sin", "cos", "tan", "log", "ln"].includes(buttonName)) {
+    // Trigonometric and logarithmic functions
     let value = null;
     if (obj.next !== null && obj.next !== undefined) {
       value = parseFloat(obj.next);
@@ -24,17 +24,39 @@ export default function calculate(obj, buttonName) {
     if (value === null || isNaN(value)) {
       return {};
     }
-    const radians = value * (Math.PI / 180);
+
     let result = "";
-    if (buttonName === "sin") {
-      result = Math.sin(radians);
-    } else if (buttonName === "cos") {
-      result = Math.cos(radians);
-    } else if (buttonName === "tan") {
-      result = Math.tan(radians);
+
+    if (["sin", "cos", "tan"].includes(buttonName)) {
+      // Trigonometric functions use radians; input assumed to be degrees, so convert to radians:
+      const radians = value * (Math.PI / 180);
+      if (buttonName === "sin") {
+        result = Math.sin(radians);
+      } else if (buttonName === "cos") {
+        result = Math.cos(radians);
+      } else if (buttonName === "tan") {
+        result = Math.tan(radians);
+      }
+      // Round to avoid long decimals
+      result = Math.round((result + Number.EPSILON) * 1000000000) / 1000000000;
+    } else if (buttonName === "log") {
+      // Logarithm base 10
+      if (value <= 0) {
+        result = 'Error';
+      } else {
+        result = Math.log10(value);
+        result = Math.round((result + Number.EPSILON) * 1000000000) / 1000000000;
+      }
+    } else if (buttonName === "ln") {
+      // Natural logarithm
+      if (value <= 0) {
+        result = 'Error';
+      } else {
+        result = Math.log(value);
+        result = Math.round((result + Number.EPSILON) * 1000000000) / 1000000000;
+      }
     }
-    // Round to avoid long decimals
-    result = Math.round((result + Number.EPSILON) * 1000000000) / 1000000000;
+
     return {
       total: result.toString(),
       next: null,


### PR DESCRIPTION
## Summary
- Added 'log' (base 10 logarithm) and 'ln' (natural logarithm) calculator buttons to the UI (ButtonPanel.js), displaying them at the top alongside other scientific functions.
- Integrated handling of 'log' and 'ln' functionality in calculate.js, with result rounding and error display for non-positive input.

## Implementation Details
- The two buttons are visible in the first row now (before sin, cos, tan).
- For log(x) and ln(x), if the input value is not a real positive number, 'Error' is shown in the display.
- The modification style matches the existing trigonometric feature handling.

## No breaking changes.

## Manual Test:
- Press log or ln after entering a positive number and observe correct result.
- Try 0 or negative input and observe display of 'Error'.

All commits and file changes are included.
