### PR TITLE
Add tap/click animation to calculator buttons (opacity and scale, CSS only)

### DIFF
--- a/src/component/Button.css
+++ b/src/component/Button.css
@@ -15,6 +15,12 @@
   margin: 0 1px 0 0;
   flex: 1 0 auto;
   padding: 0;
+  transition: opacity 0.18s cubic-bezier(.4,2,.6,1), transform 0.18s cubic-bezier(.4,2,.6,1);
+}
+
+.component-button button:active {
+  opacity: 0.5;
+  transform: scale(0.97);
 }
 
 .component-button:last-child button {


### PR DESCRIPTION
This PR adds a CSS animation for the calculator buttons to provide tactile feedback on user interaction (tap or click).

- On button tap/click (:active state): buttons fade to 0.5 opacity and scale down slightly.
- Animation uses a smooth transition for both opacity and transform.
- Solution is pure CSS for broad compatibility and performance.

Enhances user experience significantly, especially on mobile/touch devices.

No JavaScript changes, no impact to logic.

**Tested on:**
- Desktop (Chrome, Firefox)
- Mobile simulator

---
Related to user request for improved button feedback on press/tap.
