### PR TITLE
Add random number generator buttons above calculator keys

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -10,12 +10,32 @@ export default class ButtonPanel extends React.Component {
   };
 
   handleClick = buttonName => {
+    if (buttonName === "Rand9") {
+      const rand = Math.floor(Math.random() * 10).toString();
+      this.props.clickHandler(rand);
+      return;
+    }
+    if (buttonName === "Rand99") {
+      const rand = Math.floor(Math.random() * 100).toString();
+      this.props.clickHandler(rand);
+      return;
+    }
+    if (buttonName === "Rand999") {
+      const rand = Math.floor(Math.random() * 1000).toString();
+      this.props.clickHandler(rand);
+      return;
+    }
     this.props.clickHandler(buttonName);
   };
 
   render() {
     return (
       <div className="component-button-panel">
+        <div>
+          <Button name="Rand9" clickHandler={this.handleClick} />
+          <Button name="Rand99" clickHandler={this.handleClick} />
+          <Button name="Rand999" clickHandler={this.handleClick} />
+        </div>
         <div>
           <Button name="sin" clickHandler={this.handleClick} />
           <Button name="cos" clickHandler={this.handleClick} />


### PR DESCRIPTION
- Introduced three new buttons: Rand9, Rand99, Rand999, now positioned above the existing calculator buttons.
- Clicking these generates a random number within their respective ranges (0-9, 0-99, 0-999) and inputs it into the calculator like a regular digit entry.
- No changes to underlying logic were required, ensuring consistent user experience.

Tested new buttons for suitable behavior and seamless integration with existing layout and logic.