### PR TITLE
Add random number generator buttons above calculator buttons

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -12,7 +12,26 @@ export default class App extends React.Component {
   };
 
   handleClick = buttonName => {
-    this.setState(calculate(this.state, buttonName));
+    // Handle random number buttons
+    if (buttonName === "Rand 1" || buttonName === "Rand 2" || buttonName === "Rand 3") {
+      let digits = 1;
+      if (buttonName === "Rand 2") digits = 2;
+      if (buttonName === "Rand 3") digits = 3;
+      // Generate a random number with the specified digits
+      // First digit should not be zero if digits > 1
+      let min = Math.pow(10, digits - 1);
+      let max = Math.pow(10, digits) - 1;
+      if (digits === 1) min = 0;
+      const randNumber = Math.floor(Math.random() * (max - min + 1)) + min;
+      // Set this random number as the current input (next)
+      this.setState({
+        total: null,
+        next: randNumber.toString(),
+        operation: null,
+      });
+    } else {
+      this.setState(calculate(this.state, buttonName));
+    }
   };
 
   render() {

--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -16,6 +16,12 @@ export default class ButtonPanel extends React.Component {
   render() {
     return (
       <div className="component-button-panel">
+        {/* Random Number Generator Buttons */}
+        <div>
+          <Button name="Rand 1" clickHandler={this.handleClick} />
+          <Button name="Rand 2" clickHandler={this.handleClick} />
+          <Button name="Rand 3" clickHandler={this.handleClick} />
+        </div>
         <div>
           <Button name="sin" clickHandler={this.handleClick} />
           <Button name="cos" clickHandler={this.handleClick} />


### PR DESCRIPTION
### Features Implemented
- Added 'Rand 1', 'Rand 2', and 'Rand 3' buttons as a new row above existing calculator buttons.
- Clicking these buttons generates a random 1-digit, 2-digit, or 3-digit number respectively and displays it as the calculator's input.
- No disruption to existing logic/chains, integrates cleanly with current calculator workflow.
- Changes are limited to ButtonPanel and App for clear separation and maintainability.

### How to Test
1. Run the React app.
2. Click each 'Rand X' button at the top of the calculator.
3. A random number with the designated number of digits is shown as the current input; calculation flow continues as expected.

No breaking changes introduced.