### PR TITLE
Add trigonometric function tests (sin, cos, tan) to calculator logic

### DIFF
--- a/src/logic/trig.test.js
+++ b/src/logic/trig.test.js
@@ -1,0 +1,57 @@
+import calculate from "./calculate";
+import chai from "chai";
+
+chai.config.truncateThreshold = 0;
+const expect = chai.expect;
+
+function pressButtons(buttons) {
+  const value = {};
+  buttons.forEach((button) => {
+    Object.assign(value, calculate(value, button));
+  });
+  Object.keys(value).forEach((key) => {
+    if (value[key] === null) {
+      delete value[key];
+    }
+  });
+  return value;
+}
+
+describe("trigonometric functions (sin, cos, tan)", function () {
+  it("sin(0) = 0", function () {
+    const result = pressButtons(["0", "sin"]);
+    expect(result).to.deep.equal({ total: "0" });
+  });
+  it("sin(90) ≈ 1", function () {
+    const result = pressButtons(["90", "sin"]);
+    expect(result.total).to.be.closeTo(1, 1e-9);
+  });
+  it("cos(0) = 1", function () {
+    const result = pressButtons(["0", "cos"]);
+    expect(result.total).to.be.closeTo(1, 1e-9);
+  });
+  it("cos(180) = -1", function () {
+    const result = pressButtons(["180", "cos"]);
+    expect(result.total).to.be.closeTo(-1, 1e-9);
+  });
+  it("tan(0) = 0", function () {
+    const result = pressButtons(["0", "tan"]);
+    expect(result).to.deep.equal({ total: "0" });
+  });
+  it("tan(45) ≈ 1", function () {
+    const result = pressButtons(["45", "tan"]);
+    expect(Number(result.total)).to.be.closeTo(1, 1e-9);
+  });
+  it("tan(90) = Infinity (should have large value)", function () {
+    const result = pressButtons(["90", "tan"]);
+    expect(Math.abs(Number(result.total))).to.be.greaterThan(1e8);
+  });
+  it("sin(-90) ≈ -1", function () {
+    const result = pressButtons(["-90", "sin"]);
+    expect(Number(result.total)).to.be.closeTo(-1, 1e-9);
+  });
+  it("cos(360) ≈ 1", function () {
+    const result = pressButtons(["360", "cos"]);
+    expect(Number(result.total)).to.be.closeTo(1, 1e-9);
+  });
+});


### PR DESCRIPTION
This pull request adds comprehensive unit tests for trigonometric functions (sin, cos, tan) in the calculator logic. The tests cover standard and edge angle cases, ensuring calculator correctness for trigonometric operations.

- Tests for sin, cos, tan at key angles, including 0°, 45°, 90°, 180°, 360°, and negatives
- Ensures results match expected mathematical values, including special cases (e.g., tan(90) ≈ Infinity)

Test file: `src/logic/trig.test.js`

No existing code is changed; only new test coverage is added.