### PR TITLE
Remove trigonometric buttons (sin, cos, tan) from UI and logic

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -16,11 +16,7 @@ export default class ButtonPanel extends React.Component {
   render() {
     return (
       <div className="component-button-panel">
-        <div>
-          <Button name="sin" clickHandler={this.handleClick} />
-          <Button name="cos" clickHandler={this.handleClick} />
-          <Button name="tan" clickHandler={this.handleClick} />
-        </div>
+        
         <div>
           <Button name="AC" clickHandler={this.handleClick} />
           <Button name="+/-" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,34 +13,7 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
-  if (["sin", "cos", "tan"].includes(buttonName)) {
-    // Trigonometric functions use radians; input assumed to be degrees, so convert to radians:
-    let value = null;
-    if (obj.next !== null && obj.next !== undefined) {
-      value = parseFloat(obj.next);
-    } else if (obj.total !== null && obj.total !== undefined) {
-      value = parseFloat(obj.total);
-    }
-    if (value === null || isNaN(value)) {
-      return {};
-    }
-    const radians = value * (Math.PI / 180);
-    let result = "";
-    if (buttonName === "sin") {
-      result = Math.sin(radians);
-    } else if (buttonName === "cos") {
-      result = Math.cos(radians);
-    } else if (buttonName === "tan") {
-      result = Math.tan(radians);
-    }
-    // Round to avoid long decimals
-    result = Math.round((result + Number.EPSILON) * 1000000000) / 1000000000;
-    return {
-      total: result.toString(),
-      next: null,
-      operation: null,
-    };
-  }
+  // Trigonometric functions have been removed (sin, cos, tan)
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
This pull request removes the trigonometric buttons (sin, cos, tan) from the calculator UI and the supporting logic in the codebase, as per the requested feature update.

**Changes made:**
- Removed the sin, cos, tan <Button> components from ButtonPanel.js
- Removed the trig button handling logic from logic/calculate.js

No changes to tests were necessary because these buttons were not covered in App.test.js.

The feature is now complete and regression-tested locally.