### PR TITLE
Add 'e' button to input Euler's number

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -51,6 +51,18 @@ export default function calculate(obj, buttonName) {
       operation: null,
     };
   }
+
+  // Handle Euler's number button
+  if (buttonName === "e") {
+    const eVal = Math.E.toString();
+    if (obj.operation) {
+      // If in the middle of entering a new number (after an operation)
+      return { ...obj, next: eVal };
+    } else {
+      // If not, just replace whatever is being entered or start new
+      return { total: null, next: eVal, operation: null };
+    }
+  }
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
- Adds an 'e' button to the calculator interface (ButtonPanel)
- Handles logic so pressing 'e' sets next/total to Euler's number (Math.E ~ 2.718...)
- This matches the behavior for special constant buttons and allows calculations using Euler's number

Test:
- Pressing 'e' after an operator sets the next number to Euler's number.
- Pressing 'e' initially sets the display to Euler's number.
- Further operations/calculations work as expected with this value.
