### PR TITLE
Remove trigonometric buttons from ButtonPanel

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -17,9 +17,6 @@ export default class ButtonPanel extends React.Component {
     return (
       <div className="component-button-panel">
         <div>
-          <Button name="sin" clickHandler={this.handleClick} />
-          <Button name="cos" clickHandler={this.handleClick} />
-          <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
         </div>
         <div>


### PR DESCRIPTION
Removed the sin, cos, and tan calculator buttons from the first row of ButtonPanel.js, leaving only the square root (√) button. This change addresses the request to eliminate trigonometric button functionality from the calculator UI.