### PR TITLE
Add 'e' (Euler's number) button to calculator

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,6 +13,21 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (buttonName === "e") {
+    // When pressing the 'e' button, insert Euler's number (2.718281828) as current value
+    if (obj.operation) {
+      return {
+        ...obj,
+        next: "2.718281828"
+      };
+    } else {
+      return {
+        total: null,
+        next: "2.718281828",
+        operation: null,
+      };
+    }
+  }
   if (["sin", "cos", "tan", "√"].includes(buttonName)) {
     // Supported scientific functions. Trig use radians; input is degrees. √ operates on present value.
     let value = null;


### PR DESCRIPTION
This PR adds an 'e' button to the calculator UI, which inputs Euler's number (2.718281828) into the display when pressed. The implementation updates both the button layout and the calculation logic.

- ButtonPanel.js: Adds 'e' button alongside scientific function buttons
- calculate.js: Handles 'e' button press to inject 2.718281828 as next or total value

No breaking changes. Follows existing button and value handling patterns.