### PR TITLE
Add e constant button and logic support

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -3,6 +3,8 @@ import Big from "big.js";
 import operate from "./operate";
 import isNumber from "./isNumber";
 
+const E_CONSTANT = Math.E.toString();
+
 /**
  * Given a button name and a calculator data object, return an updated
  * calculator data object.
@@ -50,6 +52,14 @@ export default function calculate(obj, buttonName) {
       next: null,
       operation: null,
     };
+  }
+
+  // E button logic
+  if (buttonName === "e") {
+    if (obj.operation) {
+      return { next: E_CONSTANT };
+    }
+    return { next: E_CONSTANT, total: null };
   }
   if (buttonName === "AC") {
     return {


### PR DESCRIPTION
- Added an "e" button alongside scientific buttons in ButtonPanel.
- Implemented logic so that clicking button "e" inputs Euler's number (2.718...) as next.
- Maintains calculator's prior behavior for all other buttons.

No existing button or calculation logic is impacted; unit and display logic remain consistent. Ready for review.