### PR TITLE
feat: add an 'e' button (Euler's number) to calculator

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -20,6 +20,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="sin" clickHandler={this.handleClick} />
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
         </div>
         <div>

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -51,6 +51,24 @@ export default function calculate(obj, buttonName) {
       operation: null,
     };
   }
+
+  // Handling e button to insert Euler's number
+  if (buttonName === "e") {
+    // If entering a number, append e to next; else, start new
+    if (obj.operation) {
+      // If operation is pending, act like number entry for next
+      return {
+        ...obj,
+        next: (obj.next ? obj.next : "") + Math.E.toString(),
+      };
+    } else {
+      return {
+        ...obj,
+        next: (obj.next ? obj.next : "") + Math.E.toString(),
+        total: null,
+      };
+    }
+  }
   if (buttonName === "AC") {
     return {
       total: null,

--- a/src/logic/calculate.test.js
+++ b/src/logic/calculate.test.js
@@ -186,4 +186,20 @@ describe("calculate", function() {
     total: "2",
     operation: 'x'
   });
+
+  // Test e button as single input
+  test(["e"], {
+    next: Math.E.toString()
+  });
+  // Test e button after number input
+  test(["2", "e"], {
+    next: "2" + Math.E.toString(),
+    total: null
+  });
+  // Test e button after operator
+  test(["2", "+", "e"], {
+    next: Math.E.toString(),
+    total: "2",
+    operation: "+"
+  });
 });


### PR DESCRIPTION
- Adds a new button 'e' to the calculator UI (ButtonPanel) which inserts the Euler number (≈ 2.718) into the current input.
- Updates calculate.js to handle inserting Math.E when the button is pressed, following number-entry logic.
- Adds tests to calculate.test.js to verify the correct behavior and edge cases of the new e button.

This allows the user to easily use Euler's number in calculations, similar to π on scientific calculators.