### PR TITLE
Add Euler's number (e) button to calculator UI and logic

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -51,6 +51,22 @@ export default function calculate(obj, buttonName) {
       operation: null,
     };
   }
+
+  // Handle the 'e' button to input Euler's number
+  if (buttonName === "e") {
+    // Add Euler's number as next if entering a new operand, else as total if nothing yet
+    const eValue = Math.E.toString();
+    if (obj.operation) {
+      // If operation is set, add 'e' as 'next'
+      return { ...obj, next: eValue };
+    }
+    // If entering a new calculation or replacing current
+    return {
+      total: null,
+      next: eValue,
+      operation: null,
+    };
+  }
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
This PR adds an "e" button to the calculator, allowing users to input Euler's number (approximately 2.718) directly into calculations. The UI has been updated to include the button, and logic has been implemented to handle its input appropriately. No changes to existing tests were necessary; please review functionality and add more tests if advanced behavior is desired.