### PR TITLE
Add 'e' button to calculator and input logic for Euler's number

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -51,6 +51,20 @@ export default function calculate(obj, buttonName) {
       operation: null,
     };
   }
+
+  // Handle e button (Euler's number)
+  if (buttonName === "e") {
+    if (obj.operation) {
+      // In the middle of an operation, set as next
+      return { ...obj, next: "2.718281828459045" };
+    }
+    // Otherwise, set as next and clear previous calculation
+    return {
+      total: null,
+      next: "2.718281828459045",
+      operation: null,
+    };
+  }
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
This PR adds an 'e' button to the calculator keypad (in the first row, alongside function buttons) and ensures that, when pressed, it inputs Euler's number (2.718281828459045) into the current expression, consistent with other mathematical constants or functions.

- UI: Adds button labeled 'e' to ButtonPanel
- Logic: Updates calculate.js to handle 'e' by inputting its value as next or total appropriately

No breaking changes or behavioral changes for other buttons.

Closes # (if there is an associated issue)