### PR TITLE
Add 'e' button for mathematical constant e

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.e-button.test.js
+++ b/src/logic/calculate.e-button.test.js
@@ -1,0 +1,38 @@
+import calculate from "./calculate";
+import chai from "chai";
+
+chai.config.truncateThreshold = 0;
+const expect = chai.expect;
+
+function pressButtons(buttons) {
+  const value = {};
+  buttons.forEach(button => {
+    Object.assign(value, calculate(value, button));
+  });
+  Object.keys(value).forEach(key => {
+    if (value[key] === null) delete value[key];
+  });
+  return value;
+}
+
+describe("calculate e button", function() {
+  it('pressing e sets next to Math.E', () => {
+    expect(pressButtons(["e"])).to.deep.equal({ next: "2.718281828459045", total: null });
+  });
+
+  it('inserts e after an operation', () => {
+    expect(pressButtons(["6", "+", "e"])).to.deep.equal({ next: "2.718281828459045", total: "6", operation: "+" });
+  });
+
+  it('concats e if next already started', () => {
+    expect(pressButtons(["1", "e"])).to.deep.equal({ next: "12.718281828459045", total: null });
+  });
+
+  it('concats e to next if in operation', () => {
+    expect(pressButtons(["1", "+", "2", "e"])).to.deep.equal({ next: "22.718281828459045", total: "1", operation: "+" });
+  });
+
+  it('equals works when using e', () => {
+    expect(pressButtons(["1", "+", "e", "="])).to.deep.equal({ total: (1+Math.E).toString() });
+  });
+});

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -51,6 +51,29 @@ export default function calculate(obj, buttonName) {
       operation: null,
     };
   }
+
+  // Handle mathematical constant 'e'
+  if (buttonName === "e") {
+    const E_VALUE = "2.718281828459045";
+    // If there is an operation, we're entering the next argument
+    if (obj.operation) {
+      if (obj.next) {
+        return { next: obj.next + E_VALUE };
+      }
+      return { next: E_VALUE };
+    }
+    // If there is no operation, start fresh or append
+    if (obj.next) {
+      return {
+        next: obj.next + E_VALUE,
+        total: null,
+      };
+    }
+    return {
+      next: E_VALUE,
+      total: null,
+    };
+  }
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
- Adds an 'e' button to the calculator interface next to existing scientific functions.
- Updates calculator logic to insert the mathematical constant e (2.718...) when 'e' is pressed, similar to number entry.
- Includes unit tests for various usages of the 'e' button (standalone, with operations, chained input, and equals).

This feature aligns the UI and logic for consistent support of the constant e in calculations.