### PR TITLE
Add 'e' button for Euler's number to calculator

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -51,6 +51,17 @@ export default function calculate(obj, buttonName) {
       operation: null,
     };
   }
+
+  // Add handler for Euler's number 'e' button
+  if (buttonName === "e") {
+    // Insert Euler's number 2.718281828...
+    if (obj.operation) {
+      // currently entering 'next'
+      return { next: (obj.next || "") + "2.718281828459045" };
+    } else {
+      return { next: (obj.next ? obj.next + "2.718281828459045" : "2.718281828459045"), total: null };
+    }
+  }
   if (buttonName === "AC") {
     return {
       total: null,


### PR DESCRIPTION
- Add 'e' button to ButtonPanel to allow inserting Euler's number (2.718281828459045) into inputs.
- Extend calculate logic to handle 'e' input as a constant, similarly to digit entries.