### PR TITLE
Add 'e' button above display

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Display from "./Display";
 import ButtonPanel from "./ButtonPanel";
+import Button from "./Button";
 import calculate from "../logic/calculate";
 import "./App.css";
 
@@ -18,6 +19,7 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <Button name="e" clickHandler={this.handleClick} />
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
This PR adds an 'e' button above the display component as requested. The new button uses the existing Button component and routes click events through the main handleClick logic in App.js.

- Imports Button into App.js
- Renders <Button name="e" /> above the display

No UI or logical breaking changes introduced. Further extensions to link the 'e' button with Euler's number calculation can be handled separately.