### PR TITLE
feat: add 'e' button above display in calculator UI

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -18,6 +18,19 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <button 
+          className="special-button"
+          onClick={() => this.handleClick("e")}
+          style={{
+            margin: "0 auto 10px auto",
+            display: "block",
+            fontSize: "1.2em",
+            width: "48px",
+            height: "48px"
+          }}
+        >
+          e
+        </button>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
This pull request adds a new 'e' button (Euler's number) above the calculator display. 

- The button is placed above the display for easy access.
- Styled with minimal inline CSS for visibility and proper spacing, following existing conventions.
- The button triggers the same handler as other buttons, passing 'e' to the logic (further PRs may address calculator logic support if necessary).

This enhances usability for quick scientific calculations.