### PR TITLE
Add 'e' button for inserting Euler's number into calculator

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,6 +13,14 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (buttonName === "e") {
+    // Insert the value of mathematical constant e
+    return {
+      next: "2.718281828459045",
+      total: null,
+      operation: null,
+    };
+  }
   if (["sin", "cos", "tan", "√"].includes(buttonName)) {
     // Supported scientific functions. Trig use radians; input is degrees. √ operates on present value.
     let value = null;


### PR DESCRIPTION
This PR adds an 'e' button to the calculator, which inserts the value of Euler's number (2.718281828459045) into the display when pressed. The button appears with the scientific functions and reflects the feature request.