### PR TITLE
feat: add 'e' button above the display in calculator UI

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -18,6 +18,17 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <button
+          className="e-button"
+          style={{
+            margin: '10px auto',
+            display: 'block',
+            fontSize: '1.2em'
+          }}
+          onClick={() => this.handleClick("e")}
+        >
+          e
+        </button>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
This pull request adds a button labeled 'e' above the calculator display in the UI. When clicked, it passes the value 'e' to the calculator logic using the same handler as other buttons. This enables users to easily input Euler's number for calculations. The change is implemented minimally for easy extension if more logic is needed to process the 'e' input numerically.