### PR TITLE
Add 'e' button above display

### DIFF
--- a/src/component/App.css
+++ b/src/component/App.css
@@ -4,3 +4,47 @@
   flex-wrap: wrap;
   height: 100%;
 }
+
+.e-button {
+  align-self: flex-start;
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+  padding: 3px 12px;
+  background: #eee;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.e-button {
+  align-self: flex-start;
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+  padding: 3px 12px;
+  background: #eee;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.e-button {
+  align-self: flex-start;
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+  padding: 3px 12px;
+  background: #eee;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.e-button {
+  align-self: flex-start;
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+  padding: 3px 12px;
+  background: #eee;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  cursor: pointer;
+}

--- a/src/component/App.js
+++ b/src/component/App.js
@@ -18,6 +18,7 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <button className="e-button">e</button>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
- Added a static 'e' button visually placed above the calculator display in App.js
- Added and adjusted styling for the 'e-button' class in App.css

This implements the requested UI feature. There is no behavior attached to the button, per requirement.