### PR TITLE
Add Euler's number (e) button to calculator UI and logic

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -3,6 +3,8 @@ import Big from "big.js";
 import operate from "./operate";
 import isNumber from "./isNumber";
 
+const E_CONST = "2.718281828459045";
+
 /**
  * Given a button name and a calculator data object, return an updated
  * calculator data object.
@@ -13,6 +15,14 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (buttonName === "e") {
+    // If an operation is pending, set next; else, set next normally (as a number button)
+    if (obj.operation) {
+      return { next: E_CONST };
+    } else {
+      return { next: E_CONST, total: null };
+    }
+  }
   if (["sin", "cos", "tan", "√"].includes(buttonName)) {
     // Supported scientific functions. Trig use radians; input is degrees. √ operates on present value.
     let value = null;

--- a/src/logic/calculate.test.js
+++ b/src/logic/calculate.test.js
@@ -48,6 +48,12 @@ function test(buttons, expectation, only = false) {
 }
 
 describe("calculate", function() {
+  // --- e button tests ---
+  test(["e"], { next: "2.718281828459045" });
+  test(["e", "+", "1", "="], { total: "3.718281828459045" });
+  test(["1", "+", "e", "="], { total: "3.718281828459045" });
+  test(["e", "+/-"], { next: "-2.718281828459045" });
+  test(["e", "+", "e"], { next: "2.718281828459045", total: "2.718281828459045", operation: "+" });
   test(["6"], { next: "6" });
 
   test(["6", "6"], { next: "66" });


### PR DESCRIPTION
- Adds an 'e' button for Euler's number (2.718281828459045) to the scientific calculator panel.
- Handles 'e' button press in calculator logic so it inserts Euler's number into the input.
- Includes tests to verify correct calculator behavior with 'e'.