### PR TITLE
Add 'e' button to calculator UI and handle Euler's number input

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -21,6 +21,7 @@ export default class ButtonPanel extends React.Component {
           <Button name="cos" clickHandler={this.handleClick} />
           <Button name="tan" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
+          <Button name="e" clickHandler={this.handleClick} />
         </div>
         <div>
           <Button name="AC" clickHandler={this.handleClick} />

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -3,6 +3,8 @@ import Big from "big.js";
 import operate from "./operate";
 import isNumber from "./isNumber";
 
+const E_CONSTANT = 2.718281828459045;
+
 /**
  * Given a button name and a calculator data object, return an updated
  * calculator data object.
@@ -13,6 +15,19 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (buttonName === "e") {
+    // Input Euler's number as a constant
+    if (obj.operation) {
+      // If user is typing the right-hand operand
+      return { ...obj, next: (obj.next || "") + E_CONSTANT.toString() };
+    } else {
+      // If user is typing the left-hand operand
+      return {
+        next: (obj.next || "") + E_CONSTANT.toString(),
+        total: null,
+      };
+    }
+  }
   if (["sin", "cos", "tan", "√"].includes(buttonName)) {
     // Supported scientific functions. Trig use radians; input is degrees. √ operates on present value.
     let value = null;


### PR DESCRIPTION
- Adds an 'e' button to the calculator interface for inputting Euler's number (2.718281828459045).
- Logic in calculate.js ensures pressing the 'e' button enters the value as either the left or right operand, as appropriate for the calculator state.
- UI and logic consistent with other numerical/button inputs.
