### PR TITLE
feat: add 'e' button above the display in the calculator app

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Display from "./Display";
 import ButtonPanel from "./ButtonPanel";
+import Button from "./Button";
 import calculate from "../logic/calculate";
 import "./App.css";
 
@@ -18,6 +19,9 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: "8px" }}>
+          <Button name="e" clickHandler={this.handleClick} />
+        </div>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
- Added an 'e' button above the display in the main calculator UI.
- The button is rendered using the existing Button component and calls the main click handler.
- This allows for extension of behavior if needed in logic handling for 'e'.
