### PR TITLE
Add 'e' button above the display in App component

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -18,6 +18,16 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <button
+          style={{
+            display: "block",
+            margin: "0 auto 10px auto",
+            padding: "6px 16px",
+            fontSize: "18px"
+          }}
+        >
+          e
+        </button>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
This PR adds an 'e' button positioned above the calculator's display, as requested. The button is styled with basic centering and spacing for clarity and consistency. No extra logic is attached to the button at this stage.