### PR TITLE
Add 'e' button above calculator display

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -18,6 +18,12 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <button 
+          style={{ marginBottom: '10px', fontSize: '18px' }}
+          onClick={() => this.handleClick('e')}
+        >
+          e
+        </button>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
- Added an 'e' button above the calculator display in App.js, which calls the calculator's handleClick logic with "e" when pressed.
- UI update only; no logic changes made for handling 'e'.