### PR TITLE
feat: Add π (pi) button above display and handle logic

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Display from "./Display";
 import ButtonPanel from "./ButtonPanel";
+import Button from "./Button";
 import calculate from "../logic/calculate";
 import "./App.css";
 
@@ -18,6 +19,9 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        <div className="pi-button-wrapper" style={{ display: 'flex', justifyContent: 'flex-start', marginBottom: '0.5rem' }}>
+          <Button name="π" clickHandler={() => this.handleClick('π')} />
+        </div>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -13,6 +13,18 @@ import isNumber from "./isNumber";
  *   operation:String  +, -, etc.
  */
 export default function calculate(obj, buttonName) {
+  if (buttonName === "π") {
+    // Insert the value of pi, either as next or as total
+    const piValue = Math.PI.toString();
+    if (obj.operation) {
+      return { next: piValue };
+    }
+    return {
+      next: piValue,
+      total: null,
+      operation: null,
+    };
+  }
   if (["sin", "cos", "tan", "√"].includes(buttonName)) {
     // Supported scientific functions. Trig use radians; input is degrees. √ operates on present value.
     let value = null;


### PR DESCRIPTION
- Adds a π (pi) button positioned above the calculator display using the consistent Button component.
- Pressing π inserts the numeric value of pi (Math.PI) into the next/total value for calculations.
- Calculation logic updated to respond to "π" button and handle proper value injection.
- Visual style matches existing layout, minimal change approach.

This addresses the request to add a pi button above the display and make it functional for input.