### PR TITLE
Add trigonometric buttons (sin, cos, tan) above the display

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Display from "./Display";
 import ButtonPanel from "./ButtonPanel";
+import Button from "./Button";
 import calculate from "../logic/calculate";
 import "./App.css";
 
@@ -18,6 +19,12 @@ export default class App extends React.Component {
   render() {
     return (
       <div className="component-app">
+        {/* Trigonometric buttons above the display */}
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 10, gap: 10 }}>
+          <Button name="sin" clickHandler={this.handleClick} />
+          <Button name="cos" clickHandler={this.handleClick} />
+          <Button name="tan" clickHandler={this.handleClick} />
+        </div>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
This pull request adds a new row of trigonometric buttons (sin, cos, tan) above the calculator display, allowing users to conveniently use these functions on the current value. The logic for these functions leverages the existing implementation in calculate.js. No changes were made to the operation logic or UI styling apart from the addition of this button row.