### PR TITLE
Change trig function button labels to uppercase (SIN, COS, TAN)

### DIFF
--- a/src/component/ButtonPanel.js
+++ b/src/component/ButtonPanel.js
@@ -17,9 +17,9 @@ export default class ButtonPanel extends React.Component {
     return (
       <div className="component-button-panel">
         <div>
-          <Button name="sin" clickHandler={this.handleClick} />
-          <Button name="cos" clickHandler={this.handleClick} />
-          <Button name="tan" clickHandler={this.handleClick} />
+          <Button name="SIN" clickHandler={this.handleClick} />
+          <Button name="COS" clickHandler={this.handleClick} />
+          <Button name="TAN" clickHandler={this.handleClick} />
           <Button name="√" clickHandler={this.handleClick} />
         </div>
         <div>


### PR DESCRIPTION
Modified the button labels for the trigonometric functions in ButtonPanel.js to display as uppercase (SIN, COS, TAN) for consistency and clarity. No changes made to logic or internal code references—this only affects button label rendering in the UI.