### PR TITLE
Add π (pi) and e constant buttons above display

### DIFF
--- a/src/component/App.css
+++ b/src/component/App.css
@@ -4,3 +4,18 @@
   flex-wrap: wrap;
   height: 100%;
 }
+
+.constant-buttons button {
+  font-size: 1.2em;
+  margin: 0 0.5em;
+  background: #f2f2f2;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 0.5em 1.2em;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.constant-buttons button:hover {
+  background: #e2e2e2;
+}

--- a/src/component/App.js
+++ b/src/component/App.js
@@ -15,9 +15,17 @@ export default class App extends React.Component {
     this.setState(calculate(this.state, buttonName));
   };
 
+  handleConstantClick = value => {
+    this.setState({ next: value, total: null, operation: null });
+  };
+
   render() {
     return (
       <div className="component-app">
+        <div className="constant-buttons" style={{ display: 'flex', justifyContent: 'center', margin: '10px 0' }}>
+          <button onClick={() => this.handleConstantClick(Math.PI.toString())}>π</button>
+          <button onClick={() => this.handleConstantClick(Math.E.toString())}>e</button>
+        </div>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
- Adds π (pi) and e buttons above the calculator display.
- When pressed, sets the display to the value of Math.PI or Math.E directly.
- Updates App.js for button logic and handlers, and App.css for styling.
- No changes to core calculation logic required.

UI and function tested for correct constant display and layout integration.