### PR TITLE
Add π and e buttons above display to insert special constants

### DIFF
--- a/src/component/App.js
+++ b/src/component/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Display from "./Display";
 import ButtonPanel from "./ButtonPanel";
+import Button from "./Button";
 import calculate from "../logic/calculate";
 import "./App.css";
 
@@ -15,9 +16,24 @@ export default class App extends React.Component {
     this.setState(calculate(this.state, buttonName));
   };
 
+  handleSpecialInput = value => {
+    // If an operation is in progress, place value in "next"; otherwise, start a new calculation
+    this.setState(prevState => ({
+      ...prevState,
+      next: value,
+      // Optionally: if you want to clear operation when special is pressed standalone
+      // total: prevState.operation ? prevState.total : null,
+    }));
+  };
+
   render() {
     return (
       <div className="component-app">
+        {/* Special constants above display */}
+        <div style={{ display: "flex", justifyContent: "center", gap: 8, marginBottom: 8 }}>
+          <Button name="π" clickHandler={() => this.handleSpecialInput("3.141592653589793")} />
+          <Button name="e" clickHandler={() => this.handleSpecialInput("2.718281828459045")} />
+        </div>
         <Display value={this.state.next || this.state.total || "0"} />
         <ButtonPanel clickHandler={this.handleClick} />
       </div>


### PR DESCRIPTION
This PR adds two buttons, π and e, above the calculator display. Clicking these buttons will set the display to the value of π or e, respectively. The implementation uses the existing Button component for consistent styling. This allows users to quickly input these mathematical constants during calculations.

- π inserts 3.141592653589793
- e inserts 2.718281828459045

No other UI or logic is touched. Integration with other calculator functions remains compatible.